### PR TITLE
1.1.2: Ambiguous Null Check 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to Monify will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.1.2] - 2025-10-20
+
+## Fixed
+- ConvertFrom now uses `ReferenceEquals` instead of `==` to avoid ambiguity when the encapsulated type is a reference type (#17).
+
 # [1.1.1] - 2025-10-17
 
 ## Fixed
-- Set **Valuify** tp Version **1.7.0** instead of **1.7.0-rc.1**.
+- Set **Valuify** to Version **1.7.0** instead of **1.7.0-rc.1**.
 
 # [1.1.0] - 2025-10-17
 

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InClass.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InClass.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InInterface.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InInterface.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InRecord.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InRecord.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InRecordStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InRecordStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Nested.InStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Classes/Simple.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Classes/Simple.Expected.cs
@@ -46,7 +46,7 @@ internal static partial class Simple
                 {
                     public static implicit operator int(Simple subject)
                     {
-                        if (subject == null)
+                        if (ReferenceEquals(subject, null))
                         {
                             throw new ArgumentNullException("subject");
                         }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Nested.InClass.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Nested.InClass.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Nested.InInterface.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Nested.InInterface.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Nested.InRecord.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Nested.InRecord.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Nested.InRecordStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Nested.InRecordStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Nested.InStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Nested.InStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Records/Simple.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Records/Simple.Expected.cs
@@ -46,7 +46,7 @@ internal static partial class Simple
                 {
                     public static implicit operator int(Simple subject)
                     {
-                        if (subject == null)
+                        if (ReferenceEquals(subject, null))
                         {
                             throw new ArgumentNullException("subject");
                         }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InClass.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InClass.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InInterface.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InInterface.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InRecord.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InRecord.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InRecordStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InRecordStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InStruct.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Nested.InStruct.Expected.cs
@@ -53,7 +53,7 @@ internal static partial class Nested
                         {
                             public static implicit operator int(Inner subject)
                             {
-                                if (subject == null)
+                                if (ReferenceEquals(subject, null))
                                 {
                                     throw new ArgumentNullException("subject");
                                 }

--- a/src/Monify.Tests/Snippets/Declarations/Structs/Simple.Expected.cs
+++ b/src/Monify.Tests/Snippets/Declarations/Structs/Simple.Expected.cs
@@ -46,7 +46,7 @@ internal static partial class Simple
                 {
                     public static implicit operator int(Simple subject)
                     {
-                        if (subject == null)
+                        if (ReferenceEquals(subject, null))
                         {
                             throw new ArgumentNullException("subject");
                         }

--- a/src/Monify/Strategies/ConvertFromStrategy.cs
+++ b/src/Monify/Strategies/ConvertFromStrategy.cs
@@ -21,7 +21,7 @@ internal sealed class ConvertFromStrategy
             {
                 public static implicit operator {{subject.Value}}({{subject.Qualification}} subject)
                 {
-                    if (subject == null)
+                    if (ReferenceEquals(subject, null))
                     {
                         throw new ArgumentNullException("subject");
                     }


### PR DESCRIPTION
# Pull Request

## Description

Fixed a bug that caused the code generated by ConvertFrom to raise an ambiguous equality check due to the use of `==`, which has now been replaced with `ReferenceEquals`.

- **Type of change**: Bug Fix
- **Related issues**: #17 

## Checklist

Please ensure the following are true for your PR:

- [X] I have followed the project's [coding style guidelines](/.github/CONTRIBUTING.md).
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have verified that new and existing unit tests pass locally with my changes.
- [X] I have updated the documentation (if applicable).
- [X] I have confirmed that my code is free from warnings and errors.
- [X] I have reviewed suggestions and determined no actions is required.
- [X] I have updated the [CHANGELOG.md](CHANGELOG.md)
- [X] I have performed a self-review of my code.