### PR TITLE
Add XML documentation to MooVC.Console samples

### DIFF
--- a/src/Monify.Console/Classes/Nested/InClass/OutterForArray.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InClass/OutterForArray.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InClass;
 
+/// <summary>
+/// Provides a nested class example that uses Monify with integer array types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer class is parameterized with.</typeparam>
 public sealed partial class OutterForArray<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer array types.
+    /// </summary>
     [Monify<int[]>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InClass/OutterForInt.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InClass/OutterForInt.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InClass;
 
+/// <summary>
+/// Provides a nested class example that uses Monify with integer types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer class is parameterized with.</typeparam>
 public sealed partial class OutterForInt<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer types.
+    /// </summary>
     [Monify<int>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InClass/OutterForString.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InClass/OutterForString.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InClass;
 
+/// <summary>
+/// Provides a nested class example that uses Monify with string types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer class is parameterized with.</typeparam>
 public sealed partial class OutterForString<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for string types.
+    /// </summary>
     [Monify<string>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InInterface/IOutterForArray.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InInterface/IOutterForArray.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InInterface;
 
+/// <summary>
+/// Defines a nested interface example that uses Monify with integer array types.
+/// </summary>
+/// <typeparam name="T">The struct type that the interface is parameterized with.</typeparam>
 public partial interface IOutterForArray<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer array types.
+    /// </summary>
     [Monify<int[]>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InInterface/IOutterForInt.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InInterface/IOutterForInt.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InInterface;
 
+/// <summary>
+/// Defines a nested interface example that uses Monify with integer types.
+/// </summary>
+/// <typeparam name="T">The struct type that the interface is parameterized with.</typeparam>
 public partial interface IOutterForInt<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer types.
+    /// </summary>
     [Monify<int>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InInterface/IOutterForString.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InInterface/IOutterForString.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InInterface;
 
+/// <summary>
+/// Defines a nested interface example that uses Monify with string types.
+/// </summary>
+/// <typeparam name="T">The struct type that the interface is parameterized with.</typeparam>
 public partial interface IOutterForString<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for string types.
+    /// </summary>
     [Monify<string>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecord/OutterForArray.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecord/OutterForArray.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecord;
 
+/// <summary>
+/// Provides a nested record example that uses Monify with integer array types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record is parameterized with.</typeparam>
 public sealed partial record OutterForArray<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer array types.
+    /// </summary>
     [Monify<int[]>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecord/OutterForInt.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecord/OutterForInt.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecord;
 
+/// <summary>
+/// Provides a nested record example that uses Monify with integer types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record is parameterized with.</typeparam>
 public sealed partial record OutterForInt<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer types.
+    /// </summary>
     [Monify<int>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecord/OutterForString.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecord/OutterForString.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecord;
 
+/// <summary>
+/// Provides a nested record example that uses Monify with string types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record is parameterized with.</typeparam>
 public sealed partial record OutterForString<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for string types.
+    /// </summary>
     [Monify<string>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForArray.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForArray.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecordStruct;
 
+/// <summary>
+/// Provides a nested record struct example that uses Monify with integer array types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record struct is parameterized with.</typeparam>
 public readonly partial record struct OutterForArray<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer array types.
+    /// </summary>
     [Monify<int[]>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForInt.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForInt.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecordStruct;
 
+/// <summary>
+/// Provides a nested record struct example that uses Monify with integer types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record struct is parameterized with.</typeparam>
 public readonly partial record struct OutterForInt<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer types.
+    /// </summary>
     [Monify<int>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForString.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InRecordStruct/OutterForString.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InRecordStruct;
 
+/// <summary>
+/// Provides a nested record struct example that uses Monify with string types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer record struct is parameterized with.</typeparam>
 public readonly partial record struct OutterForString<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for string types.
+    /// </summary>
     [Monify<string>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InStruct/OutterForArray.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InStruct/OutterForArray.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InStruct;
 
+/// <summary>
+/// Provides a nested struct example that uses Monify with integer array types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer struct is parameterized with.</typeparam>
 public readonly ref partial struct OutterForArray<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer array types.
+    /// </summary>
     [Monify<int[]>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InStruct/OutterForInt.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InStruct/OutterForInt.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InStruct;
 
+/// <summary>
+/// Provides a nested struct example that uses Monify with integer types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer struct is parameterized with.</typeparam>
 public readonly ref partial struct OutterForInt<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for integer types.
+    /// </summary>
     [Monify<int>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Nested/InStruct/OutterForString.{T}.cs
+++ b/src/Monify.Console/Classes/Nested/InStruct/OutterForString.{T}.cs
@@ -1,8 +1,15 @@
 namespace Monify.Console.Classes.Nested.InStruct;
 
+/// <summary>
+/// Provides a nested struct example that uses Monify with string types.
+/// </summary>
+/// <typeparam name="T">The struct type that the outer struct is parameterized with.</typeparam>
 public readonly ref partial struct OutterForString<T>
     where T : struct
 {
+    /// <summary>
+    /// Represents the inner class decorated by Monify for string types.
+    /// </summary>
     [Monify<string>]
     public sealed partial class Inner;
 }

--- a/src/Monify.Console/Classes/Simple/SimpleForArray.cs
+++ b/src/Monify.Console/Classes/Simple/SimpleForArray.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Classes.Simple;
 
+/// <summary>
+/// Represents a simple class decorated by Monify for integer array types.
+/// </summary>
 [Monify<int[]>]
 public partial class SimpleForArray;

--- a/src/Monify.Console/Classes/Simple/SimpleForInt.cs
+++ b/src/Monify.Console/Classes/Simple/SimpleForInt.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Classes.Simple;
 
+/// <summary>
+/// Represents a simple class decorated by Monify for integer types.
+/// </summary>
 [Monify<int>]
 public partial class SimpleForInt;

--- a/src/Monify.Console/Classes/Simple/SimpleForString.cs
+++ b/src/Monify.Console/Classes/Simple/SimpleForString.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Classes.Simple;
 
+/// <summary>
+/// Represents a simple class decorated by Monify for string types.
+/// </summary>
 [Monify<string>]
 public partial class SimpleForString;

--- a/src/Monify.Console/Records/Simple/SimpleForArray.cs
+++ b/src/Monify.Console/Records/Simple/SimpleForArray.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Records.Simple;
 
+/// <summary>
+/// Represents a simple record decorated by Monify for integer array types.
+/// </summary>
 [Monify<int[]>]
 public partial record SimpleForArray;

--- a/src/Monify.Console/Records/Simple/SimpleForInt.cs
+++ b/src/Monify.Console/Records/Simple/SimpleForInt.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Records.Simple;
 
+/// <summary>
+/// Represents a simple record decorated by Monify for integer types.
+/// </summary>
 [Monify<int>]
 public partial record SimpleForInt;

--- a/src/Monify.Console/Records/Simple/SimpleForString.cs
+++ b/src/Monify.Console/Records/Simple/SimpleForString.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Records.Simple;
 
+/// <summary>
+/// Represents a simple record decorated by Monify for string types.
+/// </summary>
 [Monify<string>]
 public partial record SimpleForString;

--- a/src/Monify.Console/Structs/Simple/SimpleForArray.cs
+++ b/src/Monify.Console/Structs/Simple/SimpleForArray.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Structs.Simple;
 
+/// <summary>
+/// Represents a simple readonly struct decorated by Monify for integer array types.
+/// </summary>
 [Monify<int[]>]
 public readonly partial struct SimpleForArray;

--- a/src/Monify.Console/Structs/Simple/SimpleForInt.cs
+++ b/src/Monify.Console/Structs/Simple/SimpleForInt.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Structs.Simple;
 
+/// <summary>
+/// Represents a simple readonly struct decorated by Monify for integer types.
+/// </summary>
 [Monify<int>]
 public readonly partial struct SimpleForInt;

--- a/src/Monify.Console/Structs/Simple/SimpleForString.cs
+++ b/src/Monify.Console/Structs/Simple/SimpleForString.cs
@@ -1,4 +1,7 @@
 namespace Monify.Console.Structs.Simple;
 
+/// <summary>
+/// Represents a simple readonly struct decorated by Monify for string types.
+/// </summary>
 [Monify<string>]
 public readonly partial struct SimpleForString;


### PR DESCRIPTION
## Summary
- add XML documentation comments to the simple Monify console class, record, and struct samples
- document the nested sample types across class, interface, record, record struct, and struct scenarios

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68fe86f5c5508323af5b74323ec17f4e