### PR TITLE
Add comprehensive tests for SimpleForInt Monify output

### DIFF
--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenConstructorIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenConstructorIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenConstructorIsCalled
 {
     private const int SampleValue = 42;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualityOperatorWithIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualityOperatorWithIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenEqualityOperatorWithIntIsCalled
 {
     private const int SampleValue = 101;
@@ -12,7 +9,7 @@ public static class WhenEqualityOperatorWithIntIsCalled
     public static void GivenSubjectIsNullThenReturnFalse()
     {
         // Arrange
-        SimpleForInt subject = null!;
+        SimpleForInt? subject = default;
 
         // Act
         bool actual = subject == SampleValue;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualityOperatorWithSimpleForIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualityOperatorWithSimpleForIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenEqualityOperatorWithSimpleForIntIsCalled
 {
     private const int SampleValue = 14;
@@ -12,8 +9,8 @@ public static class WhenEqualityOperatorWithSimpleForIntIsCalled
     public static void GivenBothNullThenReturnTrue()
     {
         // Arrange
-        SimpleForInt? left = null;
-        SimpleForInt? right = null;
+        SimpleForInt? left = default;
+        SimpleForInt? right = default;
 
         // Act
         bool actual = left == right;
@@ -26,7 +23,7 @@ public static class WhenEqualityOperatorWithSimpleForIntIsCalled
     public static void GivenLeftIsNullThenReturnFalse()
     {
         // Arrange
-        SimpleForInt? left = null;
+        SimpleForInt? left = default;
         SimpleForInt right = new(SampleValue);
 
         // Act

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenEqualsWithIntIsCalled
 {
     private const int SampleValue = 36;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithObjectIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithObjectIsCalled.cs
@@ -1,9 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using System;
-using Shouldly;
-using Xunit;
-
 public static class WhenEqualsWithObjectIsCalled
 {
     private const int SampleValue = 28;
@@ -15,7 +11,7 @@ public static class WhenEqualsWithObjectIsCalled
         SimpleForInt subject = new(SampleValue);
 
         // Act
-        bool actual = subject.Equals((object?)null);
+        bool actual = subject.Equals((object?)default);
 
         // Assert
         actual.ShouldBeFalse();
@@ -46,6 +42,6 @@ public static class WhenEqualsWithObjectIsCalled
         Action act = () => subject.Equals(other);
 
         // Assert
-        Should.Throw<InvalidCastException>(act);
+        _ = Should.Throw<InvalidCastException>(act);
     }
 }

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithSimpleForIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenEqualsWithSimpleForIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenEqualsWithSimpleForIntIsCalled
 {
     private const int SampleValue = 51;
@@ -27,7 +24,7 @@ public static class WhenEqualsWithSimpleForIntIsCalled
     {
         // Arrange
         SimpleForInt subject = new(SampleValue);
-        SimpleForInt other = null!;
+        SimpleForInt? other = default;
 
         // Act
         bool actual = subject.Equals(other);

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenGetHashCodeIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenGetHashCodeIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenGetHashCodeIsCalled
 {
     private const int FirstValue = 3;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenImplicitOperatorFromIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenImplicitOperatorFromIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenImplicitOperatorFromIntIsCalled
 {
     private const int SampleValue = 77;
@@ -10,11 +7,13 @@ public static class WhenImplicitOperatorFromIntIsCalled
     [Fact]
     public static void GivenValueThenReturnsEquivalentInstance()
     {
-        // Arrange & Act
+        // Arrange
         SimpleForInt result = SampleValue;
 
-        // Assert
+        // Act
         int actual = result;
+
+        // Assert
         actual.ShouldBe(SampleValue);
     }
 }

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenImplicitOperatorToIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenImplicitOperatorToIntIsCalled.cs
@@ -1,9 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using System;
-using Shouldly;
-using Xunit;
-
 public static class WhenImplicitOperatorToIntIsCalled
 {
     private const int SampleValue = 42;
@@ -12,7 +8,7 @@ public static class WhenImplicitOperatorToIntIsCalled
     public static void GivenNullSubjectThenThrowsArgumentNullException()
     {
         // Arrange
-        SimpleForInt? subject = null;
+        SimpleForInt? subject = default;
 
         // Act
         Action act = () => _ = (int)subject!;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenInequalityOperatorWithIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenInequalityOperatorWithIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenInequalityOperatorWithIntIsCalled
 {
     private const int SampleValue = 7;
@@ -12,7 +9,7 @@ public static class WhenInequalityOperatorWithIntIsCalled
     public static void GivenSubjectIsNullThenReturnTrue()
     {
         // Arrange
-        SimpleForInt subject = null!;
+        SimpleForInt? subject = default;
 
         // Act
         bool actual = subject != SampleValue;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenInequalityOperatorWithSimpleForIntIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenInequalityOperatorWithSimpleForIntIsCalled.cs
@@ -1,8 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using Shouldly;
-using Xunit;
-
 public static class WhenInequalityOperatorWithSimpleForIntIsCalled
 {
     private const int SampleValue = 63;

--- a/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenToStringIsCalled.cs
+++ b/src/Monify.Console.Tests/Classes/Simple/SimpleForIntTests/WhenToStringIsCalled.cs
@@ -1,9 +1,5 @@
 namespace Monify.Console.Classes.Simple.SimpleForIntTests;
 
-using System;
-using Shouldly;
-using Xunit;
-
 public static class WhenToStringIsCalled
 {
     private const int SampleValue = 91;
@@ -18,6 +14,6 @@ public static class WhenToStringIsCalled
         Action act = () => subject.ToString();
 
         // Assert
-        Should.Throw<FormatException>(act);
+        _ = Should.Throw<FormatException>(act);
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated test classes under Monify.Console.Tests for the Monify-generated SimpleForInt type
- cover constructor, implicit conversions, equality/inequality operators, hash code generation, and the current ToString behavior

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_b_68fe8d17d46c8323801c253846518e71